### PR TITLE
PR: Removal of html tags and dwc-icons

### DIFF
--- a/src/main/code_snippets/button/Icon.txt
+++ b/src/main/code_snippets/button/Icon.txt
@@ -1,26 +1,15 @@
-Button notifications = new Button("""
-  <html>
-    Notifications
-    <dwc-icon name='bell' slot='suffix'></dwc-icon>
-  </html>
-""");
+notificationsIcon = TablerIcon.create("bell");
+notifications = new Button("Notifications");
+notifications.setSuffixComponent(notificationsIcon);
 
-Button settings = new Button("""
-  <html>
-    Settings
-    <dwc-icon name='settings' slot='suffix'></dwc-icon>
-  </html>
-""");
+settingsIcon = TablerIcon.create("settings");
+settings = new Button("Settings");
+settings.setIcon(settingsIcon);
 
-Button search = new Button("""
-  <html>
-    <dwc-icon name='search'></dwc-icon>
-    Search
-  </html>
-""");
+searchIcon = TablerIcon.create("search");
+search = new Button("Search");
+search.setPrefixComponent(searchIcon);
 
-Button home = new Button("""
-  <html>
-    <dwc-icon name='home'></dwc-icon>
-  </html>
-""");
+homeIcon = TablerIcon.create("home");
+home = new Button(homeIcon);
+home.setTheme(ButtonTheme.PRIMARY);

--- a/src/main/code_snippets/label/Demo.txt
+++ b/src/main/code_snippets/label/Demo.txt
@@ -1,3 +1,3 @@
 Label l1 = new Label("This is a Label component, which renders as static text on a webpage");
 Label l2 = new Label("Below is an example of an HTML ordered list rendered  using a Label: ");
-Label l3 = new Label("<html><ol><li>My First Item</li><li>My Second Item</li><li>My Third Item</li></ol><html>");
+Label l3 = new Label().setHtml("<ol><li>My First Item</li><li>My Second Item</li><li>My Third Item</li></ol>");

--- a/src/main/java/com/webforj/samples/views/applayout/AppLayoutConferenceDemoView.java
+++ b/src/main/java/com/webforj/samples/views/applayout/AppLayoutConferenceDemoView.java
@@ -13,8 +13,12 @@ import com.webforj.component.html.elements.H2;
 import com.webforj.component.html.elements.Img;
 import com.webforj.component.html.elements.Paragraph;
 import com.webforj.component.html.elements.Strong;
+import com.webforj.component.layout.applayout.AppDrawerToggle;
 import com.webforj.component.layout.applayout.AppLayout;
+import com.webforj.component.icons.Icon;
+import com.webforj.component.icons.TablerIcon;
 import com.webforj.component.tabbedpane.TabbedPane;
+import com.webforj.component.tabbedpane.Tab;
 import com.webforj.component.tabbedpane.TabbedPane.Placement;
 import com.webforj.component.tabbedpane.event.TabSelectEvent;
 import com.webforj.component.tabbedpane.TabbedPane.Alignment;
@@ -43,7 +47,7 @@ public class AppLayoutConferenceDemoView extends Composite<AppLayout> {
         .setAttribute("name", "pin"));
 
     // Header
-    Div toggle = new Div().setHtml("<dwc-icon-button name='menu-2' data-drawer-toggle><dwc-icon-button>");
+    AppDrawerToggle toggle = new AppDrawerToggle();
     Div logo = new Div();
     logo.addClassName("dwc-logo").add(
         new Img("https://documentation.webforj.com/img/webforj_icon.svg", "logo"));
@@ -73,16 +77,18 @@ public class AppLayoutConferenceDemoView extends Composite<AppLayout> {
     drawerMenu.setPlacement(Placement.LEFT);
 
     // Adding tabs to drawer menu
-    footerMenu.addTab("<dwc-icon name='address-book'></dwc-icon>");
-    footerMenu.addTab("<dwc-icon name='clipboard'></dwc-icon>");
-    footerMenu.addTab("<dwc-icon name='mail'></dwc-icon>");
-    footerMenu.addTab("<dwc-icon name='lock'></dwc-icon>");
-    footerMenu.addTab("<dwc-icon name='briefcase-2'></dwc-icon>");
-    drawerMenu.addTab("<dwc-icon name='dashboard'></dwc-icon>      Dashboard");
-    drawerMenu.addTab("<dwc-icon name='shopping-cart'></dwc-icon>  Orders");
-    drawerMenu.addTab("<dwc-icon name='users'></dwc-icon>          Customers");
-    drawerMenu.addTab("<dwc-icon name='box'></dwc-icon>            Products");
-    drawerMenu.addTab("<dwc-icon name='files'></dwc-icon>          Documents");
+
+    Icon dashboardIcon = TablerIcon.create("dashboard");
+    Icon ordersIcon = TablerIcon.create("shopping-cart");
+    Icon customersIcon = TablerIcon.create("users");
+    Icon productsIcon = TablerIcon.create("box");
+    Icon documentsIcon = TablerIcon.create("files");
+
+    drawerMenu.addTab(new Tab("Dashboard", dashboardIcon));
+    drawerMenu.addTab(new Tab("Orders", ordersIcon));
+    drawerMenu.addTab(new Tab("Customers", customersIcon));
+		drawerMenu.addTab(new Tab("Products", productsIcon));
+    drawerMenu.addTab(new Tab("Documents", documentsIcon));
 
     // Content
     demo.addToContent(
@@ -108,11 +114,11 @@ public class AppLayoutConferenceDemoView extends Composite<AppLayout> {
     footerMenu.setAlignment(Alignment.STRETCH);
 
     // Adding tabs to drawer menu
-    footerMenu.addTab("<dwc-icon name='address-book'></dwc-icon>");
-    footerMenu.addTab("<dwc-icon name='clipboard'></dwc-icon>");
-    footerMenu.addTab("<dwc-icon name='mail'></dwc-icon>");
-    footerMenu.addTab("<dwc-icon name='lock'></dwc-icon>");
-    footerMenu.addTab("<dwc-icon name='briefcase-2'></dwc-icon>");
+    footerMenu.addTab(new Tab("", TablerIcon.create("address-book")));
+    footerMenu.addTab(new Tab("", TablerIcon.create("clipboard")));
+    footerMenu.addTab(new Tab("", TablerIcon.create("mail")));
+    footerMenu.addTab(new Tab("", TablerIcon.create("lock")));
+    footerMenu.addTab(new Tab("", TablerIcon.create("briefcase-2")));
     footerMenu.addSelectListener(this::changeTitle);
   }
 

--- a/src/main/java/com/webforj/samples/views/applayout/AppLayoutFullNavbarView.java
+++ b/src/main/java/com/webforj/samples/views/applayout/AppLayoutFullNavbarView.java
@@ -8,8 +8,12 @@ import com.webforj.component.html.elements.H1;
 import com.webforj.component.html.elements.H3;
 import com.webforj.component.html.elements.Img;
 import com.webforj.component.html.elements.Paragraph;
+import com.webforj.component.icons.Icon;
+import com.webforj.component.icons.TablerIcon;
+import com.webforj.component.layout.applayout.AppDrawerToggle;
 import com.webforj.component.layout.applayout.AppLayout;
 import com.webforj.component.tabbedpane.TabbedPane.Placement;
+import com.webforj.component.tabbedpane.Tab;
 import com.webforj.component.tabbedpane.TabbedPane;
 import com.webforj.component.tabbedpane.event.TabSelectEvent;
 import com.webforj.router.annotation.FrameTitle;
@@ -36,7 +40,7 @@ public class AppLayoutFullNavbarView extends Composite<AppLayout> {
 
     // Header
     header.addClassName("layout__header").add(
-        new Div().setHtml("<dwc-icon-button name='menu-2' data-drawer-toggle><dwc-icon-button>"),
+        new AppDrawerToggle(),
         new H3("DWCJ Application"));
     demo.addToHeader(header);
     demo.setHeaderOffscreen(false);
@@ -61,13 +65,22 @@ public class AppLayoutFullNavbarView extends Composite<AppLayout> {
     drawerMenu.setPlacement(Placement.LEFT);
 
     // Adding tabs to drawer menu
-    drawerMenu.addTab("<dwc-icon name='dashboard'></dwc-icon>      Dashboard");
-    drawerMenu.addTab("<dwc-icon name='shopping-cart'></dwc-icon>  Orders");
-    drawerMenu.addTab("<dwc-icon name='users'></dwc-icon>          Customers");
-    drawerMenu.addTab("<dwc-icon name='box'></dwc-icon>            Products");
-    drawerMenu.addTab("<dwc-icon name='files'></dwc-icon>          Documents");
-    drawerMenu.addTab("<dwc-icon name='checklist'></dwc-icon>      Tasks");
-    drawerMenu.addTab("<dwc-icon name='chart-dots-2'></dwc-icon>   Analytics");
+    Icon dashboardIcon = TablerIcon.create("dashboard");
+    Icon ordersIcon = TablerIcon.create("shopping-cart");
+    Icon customersIcon = TablerIcon.create("users");
+    Icon productsIcon = TablerIcon.create("box");
+    Icon documentsIcon = TablerIcon.create("files");
+    Icon tasksIcon = TablerIcon.create("checklist");
+    Icon analyticsIcon = TablerIcon.create("chart-dots-2");
+
+    drawerMenu.addTab(new Tab("Dashboard", dashboardIcon));
+    drawerMenu.addTab(new Tab("Orders", ordersIcon));
+    drawerMenu.addTab(new Tab("Customers", customersIcon));
+		drawerMenu.addTab(new Tab("Products", productsIcon));
+    drawerMenu.addTab(new Tab("Documents", documentsIcon));
+    drawerMenu.addTab(new Tab("Tasks", tasksIcon));
+    drawerMenu.addTab(new Tab("Analytics", analyticsIcon));
+
 
     drawerMenu.onSelect(this::onTabChange);
 

--- a/src/main/java/com/webforj/samples/views/applayout/AppLayoutMobileDrawerView.java
+++ b/src/main/java/com/webforj/samples/views/applayout/AppLayoutMobileDrawerView.java
@@ -9,7 +9,11 @@ import com.webforj.component.html.elements.H2;
 import com.webforj.component.html.elements.Img;
 import com.webforj.component.html.elements.Paragraph;
 import com.webforj.component.html.elements.Strong;
+import com.webforj.component.icons.Icon;
+import com.webforj.component.icons.TablerIcon;
+import com.webforj.component.layout.applayout.AppDrawerToggle;
 import com.webforj.component.layout.applayout.AppLayout;
+import com.webforj.component.tabbedpane.Tab;
 import com.webforj.component.tabbedpane.TabbedPane;
 import com.webforj.component.tabbedpane.TabbedPane.Placement;
 import com.webforj.component.tabbedpane.TabbedPane.Alignment;
@@ -30,7 +34,7 @@ public class AppLayoutMobileDrawerView extends Composite<AppLayout> {
     demo.addToDrawerHeaderActions(new Element("dwc-icon-button")
         .setAttribute("name", "pin"));
     // Header
-    Div toggle = new Div().setHtml("<dwc-icon-button name='menu-2' data-drawer-toggle><dwc-icon-button>");
+    AppDrawerToggle toggle = new AppDrawerToggle();
     Div logo = new Div();
     logo.addClassName("dwc-logo").add(
         new Img("https://documentation.webforj.com/img/webforj_icon.svg", "logo"));
@@ -61,13 +65,21 @@ public class AppLayoutMobileDrawerView extends Composite<AppLayout> {
     drawerMenu.setPlacement(Placement.LEFT);
 
     // Adding tabs to drawer menu
-    drawerMenu.addTab("<dwc-icon name='dashboard'></dwc-icon>      Dashboard");
-    drawerMenu.addTab("<dwc-icon name='shopping-cart'></dwc-icon>  Orders");
-    drawerMenu.addTab("<dwc-icon name='users'></dwc-icon>          Customers");
-    drawerMenu.addTab("<dwc-icon name='box'></dwc-icon>            Products");
-    drawerMenu.addTab("<dwc-icon name='files'></dwc-icon>          Documents");
-    drawerMenu.addTab("<dwc-icon name='checklist'></dwc-icon>      Tasks");
-    drawerMenu.addTab("<dwc-icon name='chart-dots-2'></dwc-icon>   Analytics");
+    Icon dashboardIcon = TablerIcon.create("dashboard");
+    Icon ordersIcon = TablerIcon.create("shopping-cart");
+    Icon customersIcon = TablerIcon.create("users");
+    Icon productsIcon = TablerIcon.create("box");
+    Icon documentsIcon = TablerIcon.create("files");
+    Icon tasksIcon = TablerIcon.create("checklist");
+    Icon analyticsIcon = TablerIcon.create("chart-dots-2");
+
+    drawerMenu.addTab(new Tab("Dashboard", dashboardIcon));
+    drawerMenu.addTab(new Tab("Orders", ordersIcon));
+    drawerMenu.addTab(new Tab("Customers", customersIcon));
+		drawerMenu.addTab(new Tab("Products", productsIcon));
+    drawerMenu.addTab(new Tab("Documents", documentsIcon));
+    drawerMenu.addTab(new Tab("Tasks", tasksIcon));
+    drawerMenu.addTab(new Tab("Analytics", analyticsIcon));
 
     // Content
     demo.addToContent(
@@ -99,11 +111,11 @@ public class AppLayoutMobileDrawerView extends Composite<AppLayout> {
     footerMenu.setAlignment(Alignment.STRETCH);
 
     // Adding tabs to drawer menu
-    footerMenu.addTab("<dwc-icon name='dashboard'></dwc-icon>");
-    footerMenu.addTab("<dwc-icon name='shopping-cart'></dwc-icon>");
-    footerMenu.addTab("<dwc-icon name='users'></dwc-icon>");
-    footerMenu.addTab("<dwc-icon name='box'></dwc-icon>");
-    footerMenu.addTab("<dwc-icon name='files'></dwc-icon>");
+    footerMenu.addTab(new Tab("", TablerIcon.create("dashboard")));
+    footerMenu.addTab(new Tab("", TablerIcon.create("shopping-cart")));
+    footerMenu.addTab(new Tab("", TablerIcon.create("users")));
+    footerMenu.addTab(new Tab("", TablerIcon.create("box")));
+    footerMenu.addTab(new Tab("", TablerIcon.create("files")));
   }
 
 }

--- a/src/main/java/com/webforj/samples/views/applayout/AppLayoutMobileView.java
+++ b/src/main/java/com/webforj/samples/views/applayout/AppLayoutMobileView.java
@@ -8,8 +8,10 @@ import com.webforj.component.html.elements.H2;
 import com.webforj.component.html.elements.Img;
 import com.webforj.component.html.elements.Paragraph;
 import com.webforj.component.html.elements.Strong;
+import com.webforj.component.icons.TablerIcon;
 import com.webforj.component.layout.applayout.AppLayout;
 import com.webforj.component.layout.applayout.AppLayout.DrawerPlacement;
+import com.webforj.component.tabbedpane.Tab;
 import com.webforj.component.tabbedpane.TabbedPane;
 import com.webforj.component.tabbedpane.TabbedPane.Placement;
 import com.webforj.component.tabbedpane.TabbedPane.Alignment;
@@ -69,11 +71,11 @@ public class AppLayoutMobileView extends Composite<AppLayout> {
     footerMenu.setAlignment(Alignment.STRETCH);
 
     // Adding tabs to drawer menu
-    footerMenu.addTab("<dwc-icon name='dashboard'></dwc-icon>");
-    footerMenu.addTab("<dwc-icon name='shopping-cart'></dwc-icon>");
-    footerMenu.addTab("<dwc-icon name='users'></dwc-icon>");
-    footerMenu.addTab("<dwc-icon name='box'></dwc-icon>");
-    footerMenu.addTab("<dwc-icon name='files'></dwc-icon>");
+    footerMenu.addTab(new Tab("", TablerIcon.create("dashboard")));
+    footerMenu.addTab(new Tab("", TablerIcon.create("shopping-cart")));
+    footerMenu.addTab(new Tab("", TablerIcon.create("users")));
+    footerMenu.addTab(new Tab("", TablerIcon.create("box")));
+    footerMenu.addTab(new Tab("", TablerIcon.create("files")));
   }
 
 }

--- a/src/main/java/com/webforj/samples/views/applayout/AppLayoutMultipleHeadersView.java
+++ b/src/main/java/com/webforj/samples/views/applayout/AppLayoutMultipleHeadersView.java
@@ -8,7 +8,11 @@ import com.webforj.component.html.elements.H1;
 import com.webforj.component.html.elements.H3;
 import com.webforj.component.html.elements.Img;
 import com.webforj.component.html.elements.Paragraph;
+import com.webforj.component.icons.Icon;
+import com.webforj.component.icons.TablerIcon;
+import com.webforj.component.layout.applayout.AppDrawerToggle;
 import com.webforj.component.layout.applayout.AppLayout;
+import com.webforj.component.tabbedpane.Tab;
 import com.webforj.component.tabbedpane.TabbedPane;
 import com.webforj.component.tabbedpane.TabbedPane.Placement;
 import com.webforj.component.tabbedpane.event.TabSelectEvent;
@@ -38,7 +42,7 @@ public class AppLayoutMultipleHeadersView extends Composite<AppLayout> {
 
 		// Header
 		header.addClassName("layout__header").add(
-				new Div().setHtml("<dwc-icon-button name='menu-2' data-drawer-toggle><dwc-icon-button>"),
+				new AppDrawerToggle(),
 				new H3("DWCJ Application"));
 		demo.addToHeader(header);
 
@@ -62,13 +66,21 @@ public class AppLayoutMultipleHeadersView extends Composite<AppLayout> {
 		drawerMenu.setPlacement(Placement.LEFT);
 
 		// Adding tabs to drawer menu
-		drawerMenu.addTab("<dwc-icon name='dashboard'></dwc-icon>      Dashboard");
-		drawerMenu.addTab("<dwc-icon name='shopping-cart'></dwc-icon>  Orders");
-		drawerMenu.addTab("<dwc-icon name='users'></dwc-icon>          Customers");
-		drawerMenu.addTab("<dwc-icon name='box'></dwc-icon>            Products");
-		drawerMenu.addTab("<dwc-icon name='files'></dwc-icon>          Documents");
-		drawerMenu.addTab("<dwc-icon name='checklist'></dwc-icon>      Tasks");
-		drawerMenu.addTab("<dwc-icon name='chart-dots-2'></dwc-icon>   Analytics");
+    Icon dashboardIcon = TablerIcon.create("dashboard");
+    Icon ordersIcon = TablerIcon.create("shopping-cart");
+    Icon customersIcon = TablerIcon.create("users");
+    Icon productsIcon = TablerIcon.create("box");
+    Icon documentsIcon = TablerIcon.create("files");
+    Icon tasksIcon = TablerIcon.create("checklist");
+    Icon analyticsIcon = TablerIcon.create("chart-dots-2");
+
+    drawerMenu.addTab(new Tab("Dashboard", dashboardIcon));
+    drawerMenu.addTab(new Tab("Orders", ordersIcon));
+    drawerMenu.addTab(new Tab("Customers", customersIcon));
+		drawerMenu.addTab(new Tab("Products", productsIcon));
+    drawerMenu.addTab(new Tab("Documents", documentsIcon));
+    drawerMenu.addTab(new Tab("Tasks", tasksIcon));
+    drawerMenu.addTab(new Tab("Analytics", analyticsIcon));
 
 		drawerMenu.onSelect(this::onTabChange);
 		// Content
@@ -83,10 +95,16 @@ public class AppLayoutMultipleHeadersView extends Composite<AppLayout> {
 		secondMenu.setBodyHidden(true);
 		secondMenu.setBorderless(true);
 
-		secondMenu.addTab("<dwc-icon name='report-money'></dwc-icon> Sales");
-		secondMenu.addTab("<dwc-icon name='building'></dwc-icon> Enterprise");
-		secondMenu.addTab("<dwc-icon name='credit-card'></dwc-icon> Payments");
-		secondMenu.addTab("<dwc-icon name='history'></dwc-icon> History");
+		Icon salesIcon = TablerIcon.create("report-money");
+    Icon enterpriseIcon = TablerIcon.create("building");
+    Icon paymentsIcon = TablerIcon.create("credit-card");
+    Icon historyIcon = TablerIcon.create("history");
+
+    secondMenu.addTab(new Tab("Sales", salesIcon));
+    secondMenu.addTab(new Tab("Enterprise", enterpriseIcon));
+    secondMenu.addTab(new Tab("Payments", paymentsIcon));
+		secondMenu.addTab(new Tab("History", historyIcon));
+
 	}
 
 	private void onTabChange(TabSelectEvent ev) {

--- a/src/main/java/com/webforj/samples/views/applayout/AppLayoutStickyToolbarView.java
+++ b/src/main/java/com/webforj/samples/views/applayout/AppLayoutStickyToolbarView.java
@@ -9,7 +9,11 @@ import com.webforj.component.html.elements.H2;
 import com.webforj.component.html.elements.H3;
 import com.webforj.component.html.elements.Img;
 import com.webforj.component.html.elements.Paragraph;
+import com.webforj.component.icons.Icon;
+import com.webforj.component.icons.TablerIcon;
+import com.webforj.component.layout.applayout.AppDrawerToggle;
 import com.webforj.component.layout.applayout.AppLayout;
+import com.webforj.component.tabbedpane.Tab;
 import com.webforj.component.tabbedpane.TabbedPane;
 import com.webforj.component.tabbedpane.TabbedPane.Placement;
 import com.webforj.router.annotation.FrameTitle;
@@ -38,7 +42,7 @@ public class AppLayoutStickyToolbarView extends Composite<AppLayout> {
 
     // Header
     header.addClassName("layout__header").add(
-        new Div().setHtml("<dwc-icon-button name='menu-2' data-drawer-toggle><dwc-icon-button>"),
+        new AppDrawerToggle(),
         new H3("DWCJ Application"));
     demo.addToHeader(header);
     demo.setHeaderReveal(true);
@@ -62,13 +66,21 @@ public class AppLayoutStickyToolbarView extends Composite<AppLayout> {
     drawerMenu.setPlacement(Placement.LEFT);
 
     // Adding tabs to drawer menu
-    drawerMenu.addTab("<dwc-icon name='dashboard'></dwc-icon>      Dashboard");
-    drawerMenu.addTab("<dwc-icon name='shopping-cart'></dwc-icon>  Orders");
-    drawerMenu.addTab("<dwc-icon name='users'></dwc-icon>          Customers");
-    drawerMenu.addTab("<dwc-icon name='box'></dwc-icon>            Products");
-    drawerMenu.addTab("<dwc-icon name='files'></dwc-icon>          Documents");
-    drawerMenu.addTab("<dwc-icon name='checklist'></dwc-icon>      Tasks");
-    drawerMenu.addTab("<dwc-icon name='chart-dots-2'></dwc-icon>   Analytics");
+    Icon dashboardIcon = TablerIcon.create("dashboard");
+    Icon ordersIcon = TablerIcon.create("shopping-cart");
+    Icon customersIcon = TablerIcon.create("users");
+    Icon productsIcon = TablerIcon.create("box");
+    Icon documentsIcon = TablerIcon.create("files");
+    Icon tasksIcon = TablerIcon.create("checklist");
+    Icon analyticsIcon = TablerIcon.create("chart-dots-2");
+
+    drawerMenu.addTab(new Tab("Dashboard", dashboardIcon));
+    drawerMenu.addTab(new Tab("Orders", ordersIcon));
+    drawerMenu.addTab(new Tab("Customers", customersIcon));
+		drawerMenu.addTab(new Tab("Products", productsIcon));
+    drawerMenu.addTab(new Tab("Documents", documentsIcon));
+    drawerMenu.addTab(new Tab("Tasks", tasksIcon));
+    drawerMenu.addTab(new Tab("Analytics", analyticsIcon));
 
     // Content
     demo.addToContent(
@@ -97,9 +109,16 @@ public class AppLayoutStickyToolbarView extends Composite<AppLayout> {
     TabbedPane secondMenu = new TabbedPane();
     secondToolbar.add(secondMenu);
     secondMenu.setBorderless(true);
-    secondMenu.addTab("<dwc-icon name='report-money'></dwc-icon> Sales");
-    secondMenu.addTab("<dwc-icon name='building'></dwc-icon> Enterprise");
-    secondMenu.addTab("<dwc-icon name='credit-card'></dwc-icon> Payments");
-    secondMenu.addTab("<dwc-icon name='history'></dwc-icon> History");
+
+		Icon salesIcon = TablerIcon.create("report-money");
+    Icon enterpriseIcon = TablerIcon.create("building");
+    Icon paymentsIcon = TablerIcon.create("credit-card");
+    Icon historyIcon = TablerIcon.create("history");
+
+    secondMenu.addTab(new Tab("Sales", salesIcon));
+    secondMenu.addTab(new Tab("Enterprise", enterpriseIcon));
+    secondMenu.addTab(new Tab("Payments", paymentsIcon));
+		secondMenu.addTab(new Tab("History", historyIcon));
+
   }
 }

--- a/src/main/java/com/webforj/samples/views/applayout/AppLayoutView.java
+++ b/src/main/java/com/webforj/samples/views/applayout/AppLayoutView.java
@@ -8,7 +8,11 @@ import com.webforj.component.html.elements.H1;
 import com.webforj.component.html.elements.H3;
 import com.webforj.component.html.elements.Img;
 import com.webforj.component.html.elements.Paragraph;
+import com.webforj.component.icons.Icon;
+import com.webforj.component.icons.TablerIcon;
+import com.webforj.component.layout.applayout.AppDrawerToggle;
 import com.webforj.component.layout.applayout.AppLayout;
+import com.webforj.component.tabbedpane.Tab;
 import com.webforj.component.tabbedpane.TabbedPane;
 import com.webforj.component.tabbedpane.TabbedPane.Placement;
 import com.webforj.component.tabbedpane.event.TabSelectEvent;
@@ -38,7 +42,7 @@ public class AppLayoutView extends Composite<AppLayout> {
 
     // Header
     header.addClassName("layout__header").add(
-        new Div().setHtml("<dwc-icon-button name='menu-2' data-drawer-toggle><dwc-icon-button>"),
+        new AppDrawerToggle(),
         new H3("DWCJ Application"));
     demo.addToHeader(header);
 
@@ -62,13 +66,21 @@ public class AppLayoutView extends Composite<AppLayout> {
     drawerMenu.setPlacement(Placement.LEFT);
 
     // Adding tabs to drawer menu
-    drawerMenu.addTab("<dwc-icon name='dashboard'></dwc-icon>      Dashboard");
-    drawerMenu.addTab("<dwc-icon name='shopping-cart'></dwc-icon>  Orders");
-    drawerMenu.addTab("<dwc-icon name='users'></dwc-icon>          Customers");
-    drawerMenu.addTab("<dwc-icon name='box'></dwc-icon>            Products");
-    drawerMenu.addTab("<dwc-icon name='files'></dwc-icon>          Documents");
-    drawerMenu.addTab("<dwc-icon name='checklist'></dwc-icon>      Tasks");
-    drawerMenu.addTab("<dwc-icon name='chart-dots-2'></dwc-icon>   Analytics");
+    Icon dashboardIcon = TablerIcon.create("dashboard");
+    Icon ordersIcon = TablerIcon.create("shopping-cart");
+    Icon customersIcon = TablerIcon.create("users");
+    Icon productsIcon = TablerIcon.create("box");
+    Icon documentsIcon = TablerIcon.create("files");
+    Icon tasksIcon = TablerIcon.create("checklist");
+    Icon analyticsIcon = TablerIcon.create("chart-dots-2");
+
+    drawerMenu.addTab(new Tab("Dashboard", dashboardIcon));
+    drawerMenu.addTab(new Tab("Orders", ordersIcon));
+    drawerMenu.addTab(new Tab("Customers", customersIcon));
+		drawerMenu.addTab(new Tab("Products", productsIcon));
+    drawerMenu.addTab(new Tab("Documents", documentsIcon));
+    drawerMenu.addTab(new Tab("Tasks", tasksIcon));
+    drawerMenu.addTab(new Tab("Analytics", analyticsIcon));
 
     drawerMenu.onSelect(this::onTabChange);
 

--- a/src/main/java/com/webforj/samples/views/button/ButtonIconView.java
+++ b/src/main/java/com/webforj/samples/views/button/ButtonIconView.java
@@ -2,7 +2,7 @@ package com.webforj.samples.views.button;
 
 import com.webforj.component.Composite;
 import com.webforj.component.button.Button;
-import com.webforj.component.button.ButtonTheme;
+import com.webforj.component.html.elements.Img;
 import com.webforj.component.layout.flexlayout.FlexLayout;
 import com.webforj.component.icons.TablerIcon;
 import com.webforj.component.icons.Icon;
@@ -17,13 +17,12 @@ import com.webforj.router.annotation.Route;
 public class ButtonIconView extends Composite<FlexLayout> {
   FlexLayout self = getBoundComponent();
   Button notifications;
-  Button settings;
-  Button search;
-  Button home;
+  Button link;
+  Button imgButton;
   Icon notificationsIcon;
   Icon settingsIcon;
-  Icon searchIcon;
-  Icon homeIcon;
+  Icon linkIcon;
+  Img imgIcon;
 
   public ButtonIconView() {
     self.setSpacing("var(--dwc-space-l)").setMargin("var(--dwc-space-l)").setStyle("flex-wrap", "wrap")
@@ -31,20 +30,15 @@ public class ButtonIconView extends Composite<FlexLayout> {
 
     notificationsIcon = TablerIcon.create("bell");
     notifications = new Button("Notifications");
-    notifications.setSuffixComponent(notificationsIcon);
+    notifications.setPrefixComponent(notificationsIcon);
 
-    settingsIcon = TablerIcon.create("settings");
-    settings = new Button("Settings");
-    settings.setIcon(settingsIcon);
+    linkIcon = TablerIcon.create("external-link");
+    link = new Button("Search");
+    link.setSuffixComponent(linkIcon);
 
-    searchIcon = TablerIcon.create("search");
-    search = new Button("Search");
-    search.setPrefixComponent(searchIcon);
+    imgIcon = new Img("https://documentation.webforj.com/img/webforj.svg");
+    imgButton = new Button(imgIcon);
 
-    homeIcon = TablerIcon.create("home");
-    home = new Button(homeIcon);
-    home.setTheme(ButtonTheme.PRIMARY);
-
-    self.add(notifications, settings, search, home);
+    self.add(notifications, link, imgButton);
   }
 }

--- a/src/main/java/com/webforj/samples/views/button/ButtonIconView.java
+++ b/src/main/java/com/webforj/samples/views/button/ButtonIconView.java
@@ -4,6 +4,8 @@ import com.webforj.component.Composite;
 import com.webforj.component.button.Button;
 import com.webforj.component.button.ButtonTheme;
 import com.webforj.component.layout.flexlayout.FlexLayout;
+import com.webforj.component.icons.TablerIcon;
+import com.webforj.component.icons.Icon;
 import com.webforj.router.annotation.FrameTitle;
 import com.webforj.router.annotation.Route;
 
@@ -18,22 +20,30 @@ public class ButtonIconView extends Composite<FlexLayout> {
   Button settings;
   Button search;
   Button home;
+  Icon notificationsIcon;
+  Icon settingsIcon;
+  Icon searchIcon;
+  Icon homeIcon;
 
   public ButtonIconView() {
     self.setSpacing("var(--dwc-space-l)").setMargin("var(--dwc-space-l)").setStyle("flex-wrap", "wrap")
         .setWidth("100%");
 
-    notifications = new Button();
-    notifications.setHtml("Notifications <dwc-icon name='bell'></dwc-icon>");
+    notificationsIcon = TablerIcon.create("bell");
+    notifications = new Button("Notifications");
+    notifications.setSuffixComponent(notificationsIcon);
 
-    settings = new Button();
-    settings.setHtml("Settings <dwc-icon name='settings'></dwc-icon>");
+    settingsIcon = TablerIcon.create("settings");
+    settings = new Button("Settings");
+    settings.setIcon(settingsIcon);
 
-    search = new Button();
-    search.setHtml("<dwc-icon name='search'></dwc-icon></dwc-icon> Search");
+    searchIcon = TablerIcon.create("search");
+    search = new Button("Search");
+    search.setPrefixComponent(searchIcon);
 
-    home = new Button("home", ButtonTheme.PRIMARY);
-    home.setHtml("<dwc-icon name='home'></dwc-icon>");
+    homeIcon = TablerIcon.create("home");
+    home = new Button(homeIcon);
+    home.setTheme(ButtonTheme.PRIMARY);
 
     self.add(notifications, settings, search, home);
   }

--- a/src/main/java/com/webforj/samples/views/drawer/DrawerWelcomeView.java
+++ b/src/main/java/com/webforj/samples/views/drawer/DrawerWelcomeView.java
@@ -6,6 +6,9 @@ import com.webforj.component.Composite;
 import com.webforj.component.Expanse;
 import com.webforj.component.button.Button;
 import com.webforj.component.button.ButtonTheme;
+import com.webforj.component.icons.TablerIcon;
+import com.webforj.component.icons.Icon;
+import com.webforj.component.layout.applayout.AppDrawerToggle;
 import com.webforj.component.drawer.Drawer;
 import com.webforj.component.drawer.Drawer.Placement;
 import com.webforj.component.html.elements.Div;
@@ -18,6 +21,7 @@ import com.webforj.component.layout.applayout.AppLayout;
 import com.webforj.component.layout.applayout.AppLayout.DrawerPlacement;
 import com.webforj.component.layout.flexlayout.FlexLayout;
 import com.webforj.component.text.Label;
+import com.webforj.component.tabbedpane.Tab;
 import com.webforj.component.tabbedpane.TabbedPane;
 import com.webforj.exceptions.WebforjException;
 import com.webforj.router.annotation.FrameTitle;
@@ -38,11 +42,9 @@ public class DrawerWelcomeView extends Composite<FlexLayout> {
 		getBoundComponent().add(demo);
 
 		// Header
-		Div iconButton = new Div();
-		iconButton.setHtml("<dwc-icon-button name='menu-2' data-drawer-toggle><dwc-icon-button>");
 
 		Strong title = new Strong("DWCJ Application");
-		header.add(iconButton, title);
+		header.add(new AppDrawerToggle(), title);
 		header.addClassName("dwc__toolbar-drawer");
 
 		demo.addToHeader(header);
@@ -56,7 +58,7 @@ public class DrawerWelcomeView extends Composite<FlexLayout> {
 		Div drawerLogo = new Div();
 		drawerLogo.addClassName("drawer__logo")
 				.add(
-						new Img("https://i.ibb.co/1n4n1Nh/logo.png\" alt=\"logo\" /></div></html>"));
+						new Img("https://i.ibb.co/1n4n1Nh/logo.png\" alt=\"logo\""));
 		drawer.add(drawerLogo);
 
 		// Drawer's Menu
@@ -68,13 +70,17 @@ public class DrawerWelcomeView extends Composite<FlexLayout> {
 		drawerMenu.setPlacement(TabbedPane.Placement.LEFT);
 
 		// Adding tabs to drawer menu
-		drawerMenu.addTab("<dwc-icon name='dashboard'></dwc-icon>      Dashboard");
-		drawerMenu.addTab("<dwc-icon name='shopping-cart'></dwc-icon>  Orders");
-		drawerMenu.addTab("<dwc-icon name='users'></dwc-icon>          Customers");
-		drawerMenu.addTab("<dwc-icon name='box'></dwc-icon>            Products");
-		drawerMenu.addTab("<dwc-icon name='files'></dwc-icon>          Documents");
-		drawerMenu.addTab("<dwc-icon name='checklist'></dwc-icon>      Tasks");
-		drawerMenu.addTab("<dwc-icon name='chart-dots-2'></dwc-icon>   Analytics");
+		Icon dashboardIcon = TablerIcon.create("dashboard");
+    Icon ordersIcon = TablerIcon.create("shopping-cart");
+    Icon customersIcon = TablerIcon.create("users");
+    Icon productsIcon = TablerIcon.create("box");
+    Icon documentsIcon = TablerIcon.create("files");
+
+    drawerMenu.addTab(new Tab("Dashboard", dashboardIcon));
+    drawerMenu.addTab(new Tab("Orders", ordersIcon));
+    drawerMenu.addTab(new Tab("Customers", customersIcon));
+		drawerMenu.addTab(new Tab("Products", productsIcon));
+    drawerMenu.addTab(new Tab("Documents", documentsIcon));
 
 		// Welcome Drawer
 

--- a/src/main/java/com/webforj/samples/views/progressbar/ProgressBarBasicView.java
+++ b/src/main/java/com/webforj/samples/views/progressbar/ProgressBarBasicView.java
@@ -3,6 +3,8 @@ package com.webforj.samples.views.progressbar;
 import com.webforj.Interval;
 import com.webforj.component.Composite;
 import com.webforj.component.button.Button;
+import com.webforj.component.icons.Icon;
+import com.webforj.component.icons.TablerIcon;
 import com.webforj.component.html.elements.Div;
 import com.webforj.component.layout.flexlayout.FlexLayout;
 import com.webforj.component.progressbar.ProgressBar;
@@ -13,9 +15,15 @@ import com.webforj.router.annotation.Route;
 @Route
 @FrameTitle("Progress Bar Basics")
 public class ProgressBarBasicView extends Composite<Div> {
-  Button start = new Button("<html><dwc-icon name='player-play'></dwc-icon></<html> Start");
-  Button pause = new Button("<html><dwc-icon name='player-pause'></dwc-icon></<html> Pause");
-  Button reset = new Button("<html><dwc-icon name='refresh'></dwc-icon></<html> Reset");
+
+  Button start = new Button("Start"); 
+	Button pause = new Button("Pause");
+	Button reset = new Button("Reset");
+  
+	Icon startIcon = TablerIcon.create("player-play");
+	Icon pauseIcon = TablerIcon.create("player-pause");
+	Icon resetIcon = TablerIcon.create("refresh");
+
   ProgressBar bar = new ProgressBar("Progress {{x}}% - value: {{value}}");
   FlexLayout buttonContainer = FlexLayout.create(start, pause, reset).build();
   FlexLayout layout = FlexLayout.create(buttonContainer, bar).vertical().build()
@@ -24,12 +32,18 @@ public class ProgressBarBasicView extends Composite<Div> {
       .setStyle("padding", "20px");
 
   public ProgressBarBasicView() {
+
+    start.setPrefixComponent(startIcon);
+    pause.setPrefixComponent(pauseIcon);
+    reset.setPrefixComponent(resetIcon);
+
     Interval interval = new Interval(0.1f, new EventListener<Interval.ElapsedEvent>() {
       @Override
       public void onEvent(Interval.ElapsedEvent event) {
+
         Integer progress = bar.getValue() + 1;
         bar.setValue(progress);
-
+        
         if (progress >= bar.getMax()) {
           event.getInterval().stop();
           start.setEnabled(false);

--- a/src/main/java/com/webforj/samples/views/progressbar/ProgressBarOrientationView.java
+++ b/src/main/java/com/webforj/samples/views/progressbar/ProgressBarOrientationView.java
@@ -5,6 +5,8 @@ import com.webforj.component.Composite;
 import com.webforj.component.Theme;
 import com.webforj.component.button.Button;
 import com.webforj.component.html.elements.Div;
+import com.webforj.component.icons.Icon;
+import com.webforj.component.icons.TablerIcon;
 import com.webforj.component.layout.flexlayout.FlexLayout;
 import com.webforj.component.progressbar.ProgressBar;
 import com.webforj.component.progressbar.ProgressBar.Orientation;
@@ -15,9 +17,14 @@ import com.webforj.router.annotation.Route;
 @Route
 @FrameTitle("Progress Bar Orientation")
 public class ProgressBarOrientationView extends Composite<Div> {
-  Button start = new Button("<html><dwc-icon name='player-play'></dwc-icon></<html> Start");
-  Button pause = new Button("<html><dwc-icon name='player-pause'></dwc-icon></<html> Pause");
-  Button reset = new Button("<html><dwc-icon name='refresh'></dwc-icon></<html> Reset");
+  Button start = new Button("Start"); 
+	Button pause = new Button("Pause");
+	Button reset = new Button("Reset");
+  
+	Icon startIcon = TablerIcon.create("player-play");
+	Icon pauseIcon = TablerIcon.create("player-pause");
+	Icon resetIcon = TablerIcon.create("refresh");
+
   ProgressBar bar = new ProgressBar(15, "Reactor Heating Up: {{x}}%");
   FlexLayout buttonContainer = FlexLayout.create(start, pause, reset).vertical().build();
   FlexLayout layout = FlexLayout.create(buttonContainer, bar).horizontal().build()
@@ -26,6 +33,11 @@ public class ProgressBarOrientationView extends Composite<Div> {
       .setStyle("padding", "20px");
 
   public ProgressBarOrientationView() {
+    
+    start.setPrefixComponent(startIcon);
+		pause.setPrefixComponent(pauseIcon);
+		reset.setPrefixComponent(resetIcon);
+
     Interval interval = new Interval(0.1f, new EventListener<Interval.ElapsedEvent>() {
       @Override
       public void onEvent(Interval.ElapsedEvent event) {

--- a/src/main/java/com/webforj/samples/views/slider/SliderInversionDemoView.java
+++ b/src/main/java/com/webforj/samples/views/slider/SliderInversionDemoView.java
@@ -28,8 +28,8 @@ public class SliderInversionDemoView extends Composite<Div> {
     Slider sl2 = new Slider().setMax(100)
         .setMin(0);
 
-    getBoundComponent().add(new Label("<html><b>Original:</b></html>"), sl1,
-        new Label("<html><b>Inverted:</b></html>"), sl2);
+    getBoundComponent().add(new Label("Original:"), sl1,
+        new Label("Inverted:"), sl2);
 
     sl1.setTicksVisible(true)
         .setMinorTickSpacing(10)

--- a/src/main/java/com/webforj/samples/views/slider/SliderLabelDemoView.java
+++ b/src/main/java/com/webforj/samples/views/slider/SliderLabelDemoView.java
@@ -47,15 +47,15 @@ public class SliderLabelDemoView extends Composite<Div> {
         entry(85, "85"));
 
     getBoundComponent().add(
-        new Label("<html><b>Labels applied with ticks disabled</b></html>")
+        new Label("Labels applied with ticks disabled")
             .setStyle("grid-column", "1")
             .setStyle("margin", "5px 0 0 10px"),
         sl1,
-        new Label("<html><b>Labels applied to tick values</b></html>")
+        new Label("Labels applied to tick values")
             .setStyle("grid-column", "1")
             .setStyle("margin", "5px 0 0 10px"),
         sl2,
-        new Label("<html><b>Labels applied to non-tick values</b></html>")
+        new Label("Labels applied to non-tick values")
             .setStyle("grid-column", "1")
             .setStyle("margin", "5px 0 0 10px"),
         sl3);

--- a/src/main/java/com/webforj/samples/views/slider/SliderMaxMinDemoView.java
+++ b/src/main/java/com/webforj/samples/views/slider/SliderMaxMinDemoView.java
@@ -27,7 +27,7 @@ public class SliderMaxMinDemoView extends Composite<Div> {
     sl2.setWidth("500px");
 
     getBoundComponent().add(
-        new Label("<html><b>Min 0, Max 10</b></html>"), sl1,
-        new Label("<html><b>Min 0, Max 100</b></html>"), sl2);
+        new Label("Min 0, Max 10"), sl1,
+        new Label("Min 0, Max 100"), sl2);
   }
 }

--- a/src/main/java/com/webforj/samples/views/slider/SliderThemesDemoView.java
+++ b/src/main/java/com/webforj/samples/views/slider/SliderThemesDemoView.java
@@ -54,11 +54,11 @@ public class SliderThemesDemoView extends Composite<Div> {
         .setWidth("500px");
 
     getBoundComponent().add(
-        new Label("<html><b>DEFAULT</b></html>"), sl1,
-        new Label("<html><b>DANGER</b></html>"), sl2,
-        new Label("<html><b>GRAY</b></html>"), sl3,
-        new Label("<html><b>INFO</b></html>"), sl4,
-        new Label("<html><b>SUCCESS</b></html>"), sl5,
-        new Label("<html><b>WARNING</b></html>"), sl6);
+        new Label("DEFAULT"), sl1,
+        new Label("DANGER"), sl2,
+        new Label("GRAY"), sl3,
+        new Label("INFO"), sl4,
+        new Label("SUCCESS"), sl5,
+        new Label("WARNING"), sl6);
   }
 }

--- a/src/main/java/com/webforj/samples/views/slider/SliderTickDemoView.java
+++ b/src/main/java/com/webforj/samples/views/slider/SliderTickDemoView.java
@@ -23,8 +23,8 @@ public class SliderTickDemoView extends Composite<Div> {
     sl2.setWidth("500px");
 
     getBoundComponent().add(
-        new Label("<html><b>No Tick Snapping</b></html>"), sl1,
-        new Label("<html><b>Tick Snapping</b></html>"), sl2);
+        new Label("No Tick Snapping"), sl1,
+        new Label("Tick Snapping"), sl2);
 
     sl1.setTicksVisible(true)
         .setMajorTickSpacing(50)

--- a/src/main/java/com/webforj/samples/views/tabbedpane/TabbedPaneActivationView.java
+++ b/src/main/java/com/webforj/samples/views/tabbedpane/TabbedPaneActivationView.java
@@ -3,7 +3,10 @@ package com.webforj.samples.views.tabbedpane;
 import com.webforj.annotation.InlineStyleSheet;
 import com.webforj.component.Composite;
 import com.webforj.component.html.elements.Div;
+import com.webforj.component.icons.Icon;
+import com.webforj.component.icons.TablerIcon;
 import com.webforj.component.optioninput.RadioButton;
+import com.webforj.component.tabbedpane.Tab;
 import com.webforj.component.tabbedpane.TabbedPane;
 import com.webforj.component.tabbedpane.TabbedPane.Activation;
 import com.webforj.router.annotation.FrameTitle;
@@ -28,11 +31,17 @@ public class TabbedPaneActivationView extends Composite<Div> {
     getBoundComponent().addClassName("window");
     getBoundComponent().add(activation, pane);
 
-    pane.addTab("<dwc-icon name='dashboard'></dwc-icon>      Dashboard");
-    pane.addTab("<dwc-icon name='shopping-cart'></dwc-icon>  Orders");
-    pane.addTab("<dwc-icon name='users'></dwc-icon>          Customers");
-    pane.addTab("<dwc-icon name='box'></dwc-icon>            Products");
-    pane.addTab("<dwc-icon name='files'></dwc-icon>          Documents");
+    Icon dashboardIcon = TablerIcon.create("dashboard");
+    Icon ordersIcon = TablerIcon.create("shopping-cart");
+    Icon customersIcon = TablerIcon.create("users");
+    Icon productsIcon = TablerIcon.create("box");
+    Icon documentsIcon = TablerIcon.create("files");
+
+    pane.addTab(new Tab("Dashboard", dashboardIcon));
+    pane.addTab(new Tab("Orders", ordersIcon));
+    pane.addTab(new Tab("Customers", customersIcon));
+		pane.addTab(new Tab("Products", productsIcon));
+    pane.addTab(new Tab("Documents", documentsIcon));
     
     activation.onCheck( e -> {
       activation.setText("Automatic");

--- a/src/main/java/com/webforj/samples/views/tabbedpane/TabbedPaneAlignmentView.java
+++ b/src/main/java/com/webforj/samples/views/tabbedpane/TabbedPaneAlignmentView.java
@@ -3,7 +3,10 @@ package com.webforj.samples.views.tabbedpane;
 import com.webforj.annotation.InlineStyleSheet;
 import com.webforj.component.Composite;
 import com.webforj.component.html.elements.Div;
+import com.webforj.component.icons.Icon;
+import com.webforj.component.icons.TablerIcon;
 import com.webforj.component.list.ChoiceBox;
+import com.webforj.component.tabbedpane.Tab;
 import com.webforj.component.tabbedpane.TabbedPane;
 import com.webforj.component.tabbedpane.TabbedPane.Alignment;
 import com.webforj.router.annotation.FrameTitle;
@@ -28,11 +31,17 @@ public class TabbedPaneAlignmentView extends Composite<Div> {
     getBoundComponent().addClassName("window");
     getBoundComponent().add(alignments, pane);
 
-    pane.addTab("<dwc-icon name='dashboard'></dwc-icon>      Dashboard");
-    pane.addTab("<dwc-icon name='shopping-cart'></dwc-icon>  Orders");
-    pane.addTab("<dwc-icon name='users'></dwc-icon>          Customers");
-    pane.addTab("<dwc-icon name='box'></dwc-icon>            Products");
-    pane.addTab("<dwc-icon name='files'></dwc-icon>          Documents");
+    Icon dashboardIcon = TablerIcon.create("dashboard");
+    Icon ordersIcon = TablerIcon.create("shopping-cart");
+    Icon customersIcon = TablerIcon.create("users");
+    Icon productsIcon = TablerIcon.create("box");
+    Icon documentsIcon = TablerIcon.create("files");
+
+    pane.addTab(new Tab("Dashboard", dashboardIcon));
+    pane.addTab(new Tab("Orders", ordersIcon));
+    pane.addTab(new Tab("Customers", customersIcon));
+		pane.addTab(new Tab("Products", productsIcon));
+    pane.addTab(new Tab("Documents", documentsIcon));
     
     for(Alignment alignment : Alignment.values()){
       alignments.add(alignment.toString());

--- a/src/main/java/com/webforj/samples/views/tabbedpane/TabbedPaneBorderView.java
+++ b/src/main/java/com/webforj/samples/views/tabbedpane/TabbedPaneBorderView.java
@@ -3,7 +3,10 @@ package com.webforj.samples.views.tabbedpane;
 import com.webforj.annotation.InlineStyleSheet;
 import com.webforj.component.Composite;
 import com.webforj.component.html.elements.Div;
+import com.webforj.component.icons.Icon;
+import com.webforj.component.icons.TablerIcon;
 import com.webforj.component.optioninput.RadioButton;
+import com.webforj.component.tabbedpane.Tab;
 import com.webforj.component.tabbedpane.TabbedPane;
 import com.webforj.router.annotation.FrameTitle;
 import com.webforj.router.annotation.Route;
@@ -28,11 +31,17 @@ public class TabbedPaneBorderView extends Composite<Div> {
     getBoundComponent().addClassName("window");
     getBoundComponent().add(border, active, pane);
 
-    pane.addTab("<dwc-icon name='dashboard'></dwc-icon>      Dashboard");
-    pane.addTab("<dwc-icon name='shopping-cart'></dwc-icon>  Orders");
-    pane.addTab("<dwc-icon name='users'></dwc-icon>          Customers");
-    pane.addTab("<dwc-icon name='box'></dwc-icon>            Products");
-    pane.addTab("<dwc-icon name='files'></dwc-icon>          Documents");
+    Icon dashboardIcon = TablerIcon.create("dashboard");
+    Icon ordersIcon = TablerIcon.create("shopping-cart");
+    Icon customersIcon = TablerIcon.create("users");
+    Icon productsIcon = TablerIcon.create("box");
+    Icon documentsIcon = TablerIcon.create("files");
+
+    pane.addTab(new Tab("Dashboard", dashboardIcon));
+    pane.addTab(new Tab("Orders", ordersIcon));
+    pane.addTab(new Tab("Customers", customersIcon));
+		pane.addTab(new Tab("Products", productsIcon));
+    pane.addTab(new Tab("Documents", documentsIcon));
 
     border.onToggle( e -> pane.setBorderless(!pane.isBorderless()));
     active.onToggle( e -> pane.setHideActiveIndicator(!pane.isHideActiveIndicator()));

--- a/src/main/java/com/webforj/samples/views/tabbedpane/TabbedPaneDemoView.java
+++ b/src/main/java/com/webforj/samples/views/tabbedpane/TabbedPaneDemoView.java
@@ -3,7 +3,10 @@ package com.webforj.samples.views.tabbedpane;
 import com.webforj.annotation.InlineStyleSheet;
 import com.webforj.component.Composite;
 import com.webforj.component.html.elements.Div;
+import com.webforj.component.icons.Icon;
+import com.webforj.component.icons.TablerIcon;
 import com.webforj.component.list.ChoiceBox;
+import com.webforj.component.tabbedpane.Tab;
 import com.webforj.component.tabbedpane.TabbedPane;
 import com.webforj.component.tabbedpane.TabbedPane.Placement;
 import com.webforj.component.tabbedpane.TabbedPane.Removal;
@@ -29,12 +32,18 @@ public class TabbedPaneDemoView extends Composite<Div> {
     getBoundComponent().addClassName("window");
     getBoundComponent().add(placements, pane);
 
-    pane.addTab("<dwc-icon name='dashboard'></dwc-icon>      Dashboard")
+    Icon dashboardIcon = TablerIcon.create("dashboard");
+    Icon ordersIcon = TablerIcon.create("shopping-cart");
+    Icon customersIcon = TablerIcon.create("users");
+    Icon productsIcon = TablerIcon.create("box");
+    Icon documentsIcon = TablerIcon.create("files");
+
+    pane.addTab(new Tab("Dashboard", dashboardIcon))
       .setClosable(true);
-    pane.addTab("<dwc-icon name='shopping-cart'></dwc-icon>  Orders");
-    pane.addTab("<dwc-icon name='users'></dwc-icon>          Customers");
-    pane.addTab("<dwc-icon name='box'></dwc-icon>            Products");
-    pane.addTab("<dwc-icon name='files'></dwc-icon>          Documents");
+    pane.addTab(new Tab("Orders", ordersIcon));
+    pane.addTab(new Tab("Customers", customersIcon));
+		pane.addTab(new Tab("Products", productsIcon));
+    pane.addTab(new Tab("Documents", documentsIcon));
 
     pane.setRemoval(Removal.AUTO);
     

--- a/src/main/java/com/webforj/samples/views/tabbedpane/TabbedPaneExpanseThemeView.java
+++ b/src/main/java/com/webforj/samples/views/tabbedpane/TabbedPaneExpanseThemeView.java
@@ -5,8 +5,11 @@ import com.webforj.component.Composite;
 import com.webforj.component.Expanse;
 import com.webforj.component.Theme;
 import com.webforj.component.html.elements.Div;
+import com.webforj.component.icons.Icon;
+import com.webforj.component.icons.TablerIcon;
 import com.webforj.component.layout.flexlayout.FlexLayout;
 import com.webforj.component.list.ChoiceBox;
+import com.webforj.component.tabbedpane.Tab;
 import com.webforj.component.tabbedpane.TabbedPane;
 import com.webforj.router.annotation.FrameTitle;
 import com.webforj.router.annotation.Route;
@@ -34,11 +37,17 @@ public class TabbedPaneExpanseThemeView extends Composite<Div> {
         .add(themes,expanses);
     getBoundComponent().add(options, pane);
 
-    pane.addTab("<dwc-icon name='dashboard'></dwc-icon>      Dashboard");
-    pane.addTab("<dwc-icon name='shopping-cart'></dwc-icon>  Orders");
-    pane.addTab("<dwc-icon name='users'></dwc-icon>          Customers");
-    pane.addTab("<dwc-icon name='box'></dwc-icon>            Products");
-    pane.addTab("<dwc-icon name='files'></dwc-icon>          Documents");
+    Icon dashboardIcon = TablerIcon.create("dashboard");
+    Icon ordersIcon = TablerIcon.create("shopping-cart");
+    Icon customersIcon = TablerIcon.create("users");
+    Icon productsIcon = TablerIcon.create("box");
+    Icon documentsIcon = TablerIcon.create("files");
+
+    pane.addTab(new Tab("Dashboard", dashboardIcon));
+    pane.addTab(new Tab("Orders", ordersIcon));
+    pane.addTab(new Tab("Customers", customersIcon));
+		pane.addTab(new Tab("Products", productsIcon));
+    pane.addTab(new Tab("Documents", documentsIcon));
     
     for(Theme theme : Theme.values()){
       themes.add(theme.toString());

--- a/src/main/java/com/webforj/samples/views/tabbedpane/TabbedPanePlacementView.java
+++ b/src/main/java/com/webforj/samples/views/tabbedpane/TabbedPanePlacementView.java
@@ -3,7 +3,10 @@ package com.webforj.samples.views.tabbedpane;
 import com.webforj.annotation.InlineStyleSheet;
 import com.webforj.component.Composite;
 import com.webforj.component.html.elements.Div;
+import com.webforj.component.icons.Icon;
+import com.webforj.component.icons.TablerIcon;
 import com.webforj.component.list.ChoiceBox;
+import com.webforj.component.tabbedpane.Tab;
 import com.webforj.component.tabbedpane.TabbedPane;
 import com.webforj.component.tabbedpane.TabbedPane.Placement;
 import com.webforj.router.annotation.FrameTitle;
@@ -28,11 +31,17 @@ public class TabbedPanePlacementView extends Composite<Div>{
     getBoundComponent().addClassName("window");
     getBoundComponent().add(placements, pane);
 
-    pane.addTab("<dwc-icon name='dashboard'></dwc-icon>      Dashboard");
-    pane.addTab("<dwc-icon name='shopping-cart'></dwc-icon>  Orders");
-    pane.addTab("<dwc-icon name='users'></dwc-icon>          Customers");
-    pane.addTab("<dwc-icon name='box'></dwc-icon>            Products");
-    pane.addTab("<dwc-icon name='files'></dwc-icon>          Documents");
+    Icon dashboardIcon = TablerIcon.create("dashboard");
+    Icon ordersIcon = TablerIcon.create("shopping-cart");
+    Icon customersIcon = TablerIcon.create("users");
+    Icon productsIcon = TablerIcon.create("box");
+    Icon documentsIcon = TablerIcon.create("files");
+
+    pane.addTab(new Tab("Dashboard", dashboardIcon));
+    pane.addTab(new Tab("Orders", ordersIcon));
+    pane.addTab(new Tab("Customers", customersIcon));
+		pane.addTab(new Tab("Products", productsIcon));
+    pane.addTab(new Tab("Documents", documentsIcon));
     
     for(Placement placement : Placement.values()){
       placements.add(placement.toString());

--- a/src/main/java/com/webforj/samples/views/tabbedpane/TabbedPaneSwipeView.java
+++ b/src/main/java/com/webforj/samples/views/tabbedpane/TabbedPaneSwipeView.java
@@ -3,6 +3,9 @@ package com.webforj.samples.views.tabbedpane;
 import com.webforj.annotation.InlineStyleSheet;
 import com.webforj.component.Composite;
 import com.webforj.component.html.elements.Div;
+import com.webforj.component.icons.Icon;
+import com.webforj.component.icons.TablerIcon;
+import com.webforj.component.tabbedpane.Tab;
 import com.webforj.component.tabbedpane.TabbedPane;
 import com.webforj.router.annotation.FrameTitle;
 import com.webforj.router.annotation.Route;
@@ -25,11 +28,17 @@ public class TabbedPaneSwipeView extends Composite<Div> {
     getBoundComponent().addClassName("window");
     getBoundComponent().add(pane);
 
-    pane.addTab("<dwc-icon name='dashboard'></dwc-icon>      Dashboard");
-    pane.addTab("<dwc-icon name='shopping-cart'></dwc-icon>  Orders");
-    pane.addTab("<dwc-icon name='users'></dwc-icon>          Customers");
-    pane.addTab("<dwc-icon name='box'></dwc-icon>            Products");
-    pane.addTab("<dwc-icon name='files'></dwc-icon>          Documents");
+    Icon dashboardIcon = TablerIcon.create("dashboard");
+    Icon ordersIcon = TablerIcon.create("shopping-cart");
+    Icon customersIcon = TablerIcon.create("users");
+    Icon productsIcon = TablerIcon.create("box");
+    Icon documentsIcon = TablerIcon.create("files");
+
+    pane.addTab(new Tab("Dashboard", dashboardIcon));
+    pane.addTab(new Tab("Orders", ordersIcon));
+    pane.addTab(new Tab("Customers", customersIcon));
+		pane.addTab(new Tab("Products", productsIcon));
+    pane.addTab(new Tab("Documents", documentsIcon));
 
     pane.setSwipeable(true);
     pane.setSwipeWithMouse(true);

--- a/src/main/java/com/webforj/samples/views/table/TableMultiSelectionView.java
+++ b/src/main/java/com/webforj/samples/views/table/TableMultiSelectionView.java
@@ -34,12 +34,13 @@ public class TableMultiSelectionView extends Composite<Div> {
       String msg = "There are no records selected";
 
       if (!records.isEmpty()) {
-        msg = "You have selected the following records"
+        msg = "<html> You have selected the following records"
             + records.stream().map(MusicRecord::getTitle).map(title -> "<li>" + title + "</li>")
-                .collect(Collectors.joining("", "<ul>", "</ul>"));
+                .collect(Collectors.joining("", "<ul>", "</ul>"))
+            + "</html>";
       }
 
-      showMessageDialog(msg + 0 + "Record Selection");
+      showMessageDialog(msg, "Record Selection");
     });
 
     getBoundComponent().add(table);

--- a/src/main/java/com/webforj/samples/views/table/TableMultiSelectionView.java
+++ b/src/main/java/com/webforj/samples/views/table/TableMultiSelectionView.java
@@ -34,10 +34,9 @@ public class TableMultiSelectionView extends Composite<Div> {
       String msg = "There are no records selected";
 
       if (!records.isEmpty()) {
-        msg = "<html> You have selected the following records"
+        msg = "You have selected the following records"
             + records.stream().map(MusicRecord::getTitle).map(title -> "<li>" + title + "</li>")
-                .collect(Collectors.joining("", "<ul>", "</ul>"))
-            + "</html>";
+                .collect(Collectors.joining("", "<ul>", "</ul>"));
       }
 
       showMessageDialog(msg + 0 + "Record Selection");

--- a/src/main/resources/css/applayout/applayout.css
+++ b/src/main/resources/css/applayout/applayout.css
@@ -47,3 +47,7 @@ html {
   border-radius: var(--dwc-border-radius-m);
   background-color: var(--dwc-surface-3);
 }
+
+dwc-tab::part(prefix) {
+  --dwc-icon-size: var(--dwc-size-xs);
+}

--- a/src/main/resources/css/applayout/applayoutMobile.css
+++ b/src/main/resources/css/applayout/applayoutMobile.css
@@ -29,7 +29,7 @@ body {
   padding: 0 var(--dwc-space-m);
   background-color: var(--dwc-color-primary);
   height: 54.21875px;
-  
+
   strong{
     color: var(--dwc-color-on-primary-text) !important;
   }
@@ -77,4 +77,8 @@ body {
   dwc-tab span {
     display: none;
   }
+}
+
+dwc-tab::part(prefix) {
+  --dwc-icon-size: var(--dwc-size-xs);
 }


### PR DESCRIPTION
This PR closes #59.

- Where html was being used in a String, replaced with the `setHtml()` method
- Cases using <dwc-icon> were repleaced with the `Icon` component and the `AppDrawerToggle` when needed