### PR TITLE
fix: Swapped question mark and period in the confirm dialog demo to m…

### DIFF
--- a/src/main/java/com/webforj/samples/views/optiondialog/confirm/ConfirmDialogConstructorView.java
+++ b/src/main/java/com/webforj/samples/views/optiondialog/confirm/ConfirmDialogConstructorView.java
@@ -14,7 +14,7 @@ public class ConfirmDialogConstructorView extends Composite<Div> {
 
   public ConfirmDialogConstructorView() {
     ConfirmDialog dialog = new ConfirmDialog(
-        "Are you sure you want to delete this file. This action cannot be reverted?", "Deletion",
+        "Are you sure you want to delete this file? This action cannot be reverted.", "Deletion",
         ConfirmDialog.OptionType.OK_CANCEL, ConfirmDialog.MessageType.QUESTION);
     dialog.setTheme(Theme.DANGER);
     dialog.setButtonTheme(ConfirmDialog.Button.FIRST, ButtonTheme.DANGER);


### PR DESCRIPTION
…ake it grammatical.

Small fix: the confirm dialog demo had a question without a question mark and a statement with a question mark.
Swapped the punctuation around to fix this.