### PR TITLE
fix: Handle invalid input in TimeFieldMinMax, resolve missing CSS reference, and remove classnames

### DIFF
--- a/src/main/java/com/webforj/samples/views/fields/timefield/TimeFieldMinMaxView.java
+++ b/src/main/java/com/webforj/samples/views/fields/timefield/TimeFieldMinMaxView.java
@@ -1,50 +1,61 @@
 package com.webforj.samples.views.fields.timefield;
 
-import com.webforj.App;
 import com.webforj.component.Composite;
+import com.webforj.component.Theme;
 import com.webforj.component.button.Button;
 import com.webforj.component.button.ButtonTheme;
 import com.webforj.component.field.TimeField;
 import com.webforj.component.layout.flexlayout.FlexAlignment;
 import com.webforj.component.layout.flexlayout.FlexLayout;
 import com.webforj.component.layout.flexlayout.FlexWrap;
+import com.webforj.component.toast.Toast;
 import com.webforj.router.annotation.FrameTitle;
 import com.webforj.router.annotation.Route;
-
 import java.time.LocalTime;
+import java.time.format.DateTimeParseException;
 
 @Route
 @FrameTitle("Time Field Min/Max")
 public class TimeFieldMinMaxView extends Composite<FlexLayout> {
 
-  TimeField meeting = new TimeField(LocalTime.of(12, 30));
-  Button confirm = new Button("Confirm", ButtonTheme.PRIMARY);
+  private TimeField meeting = new TimeField(LocalTime.of(12, 30));
+  private Button confirm = new Button("Confirm", ButtonTheme.PRIMARY);
 
   public TimeFieldMinMaxView() {
-    getBoundComponent().setWrap(FlexWrap.WRAP)
-        .setSpacing("var(--dwc-space-l")
+    getBoundComponent()
+        .setWrap(FlexWrap.WRAP)
+        .setSpacing("var(--dwc-space-l)")
         .setMargin("var(--dwc-space-m)");
-    
+
+    meeting.setWidth("250px");
+    confirm.setWidth("150px");
+
     getBoundComponent().add(meeting, confirm);
-    
     getBoundComponent().setItemAlignment(FlexAlignment.END, confirm);
 
-    LocalTime min = LocalTime.of(12, 30);
-    LocalTime max = LocalTime.of(17, 15);
-    String label = "Choose a meeting time between %s and %s:".formatted(min, max);
-    meeting.setMin(min)
-        .setMax(max);
+    meeting.setLabel("Enter a meeting time:");
 
-    meeting.setLabel(label)
-    .onModify(e -> {
+    meeting.onModify(event -> {
+      String input = event.getText();
       try {
-        LocalTime parsedTime = LocalTime.parse(e.getText());
-        meeting.setValue(parsedTime);
-        confirm.setEnabled(true);
-      } catch (Exception ex) {
+        if (input != null && !input.isEmpty()) {
+          LocalTime.parse(input);
+          confirm.setEnabled(true);
+        } else {
+          confirm.setEnabled(false);
+        }
+      } catch (DateTimeParseException ex) {
         confirm.setEnabled(false);
-        App.console().log("Invalid time input: " + e.getText());
       }
     });
+
+    confirm.onClick(e -> showToast("Meeting time confirmed!"));
+  }
+
+  private void showToast(String message) {
+    Toast toast = new Toast(message);
+    toast.setDuration(3000);
+    toast.setTheme(Theme.SUCCESS);
+    toast.open();
   }
 }

--- a/src/main/java/com/webforj/samples/views/fields/timefield/TimeFieldMinMaxView.java
+++ b/src/main/java/com/webforj/samples/views/fields/timefield/TimeFieldMinMaxView.java
@@ -12,13 +12,12 @@ import com.webforj.component.toast.Toast;
 import com.webforj.router.annotation.FrameTitle;
 import com.webforj.router.annotation.Route;
 import java.time.LocalTime;
-import java.time.format.DateTimeParseException;
 
 @Route
 @FrameTitle("Time Field Min/Max")
 public class TimeFieldMinMaxView extends Composite<FlexLayout> {
 
-  private TimeField meeting = new TimeField(LocalTime.of(12, 30));
+  private TimeField meeting = new TimeField();
   private Button confirm = new Button("Confirm", ButtonTheme.PRIMARY);
 
   public TimeFieldMinMaxView() {
@@ -26,30 +25,28 @@ public class TimeFieldMinMaxView extends Composite<FlexLayout> {
         .setWrap(FlexWrap.WRAP)
         .setSpacing("var(--dwc-space-l)")
         .setMargin("var(--dwc-space-m)");
-
+    
     meeting.setWidth("250px");
     confirm.setWidth("150px");
 
     getBoundComponent().add(meeting, confirm);
     getBoundComponent().setItemAlignment(FlexAlignment.END, confirm);
 
-    meeting.setLabel("Enter a meeting time:");
+    meeting.setLabel("Choose a meeting time:");
+    confirm.setEnabled(false);
 
-    meeting.onModify(event -> {
-      String input = event.getText();
-      try {
-        if (input != null && !input.isEmpty()) {
-          LocalTime.parse(input);
-          confirm.setEnabled(true);
-        } else {
-          confirm.setEnabled(false);
-        }
-      } catch (DateTimeParseException ex) {
-        confirm.setEnabled(false);
-      }
+    meeting.onValueChange(event -> {
+      LocalTime selectedTime = event.getValue();
+      confirm.setEnabled(selectedTime != null);
     });
 
-    confirm.onClick(e -> showToast("Meeting time confirmed!"));
+    confirm.onClick(e -> {
+      if (meeting.getValue() != null) {
+        showToast("Meeting time confirmed!");
+      } else {
+        showToast("Invalid time selected!");
+      }
+    });
   }
 
   private void showToast(String message) {

--- a/src/main/java/com/webforj/samples/views/fields/timefield/TimeFieldMinMaxView.java
+++ b/src/main/java/com/webforj/samples/views/fields/timefield/TimeFieldMinMaxView.java
@@ -1,7 +1,6 @@
 package com.webforj.samples.views.fields.timefield;
 
 import com.webforj.App;
-import com.webforj.annotation.InlineStyleSheet;
 import com.webforj.component.Composite;
 import com.webforj.component.button.Button;
 import com.webforj.component.button.ButtonTheme;
@@ -14,7 +13,6 @@ import com.webforj.router.annotation.Route;
 
 import java.time.LocalTime;
 
-@InlineStyleSheet("context://css/fields/timefield/timeFieldMinMaxView.css")
 @Route
 @FrameTitle("Time Field Min/Max")
 public class TimeFieldMinMaxView extends Composite<FlexLayout> {
@@ -38,14 +36,15 @@ public class TimeFieldMinMaxView extends Composite<FlexLayout> {
         .setMax(max);
 
     meeting.setLabel(label)
-        .onModify(e -> {
-          try {
-            meeting.setText(e.getText());
-            confirm.setEnabled(true);
-          } catch (IllegalArgumentException ex) {
-            confirm.setEnabled(false);
-          }
-          App.console().log(meeting.getValue() + "");
-        });
+    .onModify(e -> {
+      try {
+        LocalTime parsedTime = LocalTime.parse(e.getText());
+        meeting.setValue(parsedTime);
+        confirm.setEnabled(true);
+      } catch (Exception ex) {
+        confirm.setEnabled(false);
+        App.console().log("Invalid time input: " + e.getText());
+      }
+    });
   }
 }

--- a/src/main/java/com/webforj/samples/views/fields/timefield/TimeFieldView.java
+++ b/src/main/java/com/webforj/samples/views/fields/timefield/TimeFieldView.java
@@ -17,8 +17,6 @@ public class TimeFieldView extends Composite<FlexLayout> {
   public TimeFieldView() {
     getBoundComponent().setMargin("var(--dwc-space-m)");
 
-    reminder.addClassName("date__input");
-
     getBoundComponent().add(reminder);
   }
 


### PR DESCRIPTION
- Added input validation for TimeField to handle invalid time entries
- Updated `onModify` logic to validate and parse user input before setting the value.
- Disabled the confirm button for invalid inputs
- Removed missing CSS file reference (`timeFieldMinMaxView.css`)

closes #106 and closes #105