### PR TITLE
chore: Added placeholder text for NumberFieldView

### DIFF
--- a/src/main/java/com/webforj/samples/views/fields/numberfield/NumberFieldView.java
+++ b/src/main/java/com/webforj/samples/views/fields/numberfield/NumberFieldView.java
@@ -10,13 +10,13 @@ import com.webforj.router.annotation.Route;
 @FrameTitle("Number Field Demo")
 public class NumberFieldView extends Composite<FlexLayout> {
   
-  NumberField numField = new NumberField();
+  NumberField numField = new NumberField("Quantity:");
 
   public NumberFieldView() {
     getBoundComponent().setMargin("var(--dwc-space-m)");
 
     numField.setWidth("200px")
-            .setLabel("Quantity:");
+            .setPlaceholder("Enter a number...");
 
     getBoundComponent().add(numField);
   }


### PR DESCRIPTION
This PR closes Issue #160 by adding placeholder text.

The `NumberField` component by design already has a spinner that is visible when the component is in focus or when the user hovers over the component with their mouse.

![numberfield](https://github.com/user-attachments/assets/8c5ea635-5464-4928-b74f-7e89b6a5f5f4)
 